### PR TITLE
fix(notifications): prevent notification request on unsupported iOS S…

### DIFF
--- a/src/firebase/service.js
+++ b/src/firebase/service.js
@@ -21,6 +21,13 @@ const sendTokenToServer = async (token) => {
 };
 
 const requestPermission = async () => {
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  
+  if (isSafari && /iPad|iPhone|iPod/.test(navigator.userAgent)) {
+    console.log("iOS Safari doesn't support web notifications");
+    return;
+  }
+
   try {
     const permission = await Notification.requestPermission();
     if (permission !== "granted") return;


### PR DESCRIPTION
…afari

Add Safari detection to avoid requesting notification permissions on iOS Safari, which does not support web notifications. This prevents unnecessary permission prompts and improves user experience.